### PR TITLE
add alpine image, update go version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ GOTAGS ?=
 GOMAXPROCS ?= 4
 
 # Get the project metadata
-GOVERSION := 1.9.2
+GOVERSION := 1.17
 PROJECT := $(CURRENT_DIR:$(GOPATH)/src/%=%)
 OWNER := $(notdir $(patsubst %/,%,$(dir $(PROJECT))))
 NAME := $(notdir $(PROJECT))
@@ -44,7 +44,7 @@ LD_FLAGS ?= \
 	-X ${PROJECT}/version.GitCommit=${GIT_COMMIT}
 
 # List of Docker targets to build
-DOCKER_TARGETS ?= scratch
+DOCKER_TARGETS ?= scratch alpine
 
 # List of tests to run
 TEST ?= ./...
@@ -138,7 +138,6 @@ define make-docker-target
 			--rm \
 			--force-rm \
 			--no-cache \
-			--squash \
 			--compress \
 			--file="docker/${1}/Dockerfile" \
 			--build-arg="LD_FLAGS=${LD_FLAGS}" \

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine
+
+ADD "https://curl.haxx.se/ca/cacert.pem" "/etc/ssl/certs/ca-certificates.crt"
+ADD "./pkg/linux_amd64/http-echo" "/"
+RUN apk add curl
+ENTRYPOINT ["/http-echo"]

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/hashicorp/http-echo
+
+go 1.17


### PR DESCRIPTION
The alpine image can be built from this repo using:
```
make linux/amd64
make docker-build/alpine
```
And it can be pushed to the dockerhub repo: hashicorp/http-echo:alpine
```
docker push hashicorp/http-echo:alpine
```