### PR TITLE
Add option for reading from env var ECHO_TEXT

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,9 +32,15 @@ func main() {
 		os.Exit(0)
 	}
 
+	// Get text to echo from env var or flag
+	echoText := os.Getenv("ECHO_TEXT")
+	if *textFlag != "" {
+		echoText = *textFlag
+	}
+
 	// Validation
-	if *textFlag == "" {
-		fmt.Fprintln(stderrW, "Missing -text option!")
+	if echoText == "" {
+		fmt.Fprintln(stderrW, "Missing -text option or ECHO_TEXT env var!")
 		os.Exit(127)
 	}
 
@@ -46,7 +52,7 @@ func main() {
 
 	// Flag gets printed as a page
 	mux := http.NewServeMux()
-	mux.HandleFunc("/", httpLog(stdoutW, withAppHeaders(httpEcho(*textFlag))))
+	mux.HandleFunc("/", httpLog(stdoutW, withAppHeaders(httpEcho(echoText))))
 
 	// Health endpoint
 	mux.HandleFunc("/health", withAppHeaders(httpHealth()))


### PR DESCRIPTION
This is my go-to container for testing, and several times I have been restricted (e.g. by custom Helm charts) to only being able to provide environment variables.

This PR adds support for the `ECHO_TEXT` environment variable.