### PR TITLE
fix: handle SIGTERM

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/hashicorp/http-echo/version"
@@ -65,7 +66,7 @@ func main() {
 	}()
 
 	signalCh := make(chan os.Signal, 1)
-	signal.Notify(signalCh, os.Interrupt)
+	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
 
 	// Wait for interrupt
 	<-signalCh


### PR DESCRIPTION
This application doesn't terminate gracefully when run inside a container, because container runtimes (Docker, containerd, ...) and orchestrators (Kubernetes, [Nomad](https://learn.hashicorp.com/tutorials/nomad/job-update-handle-signals)) send the SIGTERM signal for termination, not SIGINT (Ctrl-C).