### PR TITLE
using non root user

### DIFF
--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -3,4 +3,13 @@ FROM alpine
 ADD "https://curl.haxx.se/ca/cacert.pem" "/etc/ssl/certs/ca-certificates.crt"
 ADD "./pkg/linux_amd64/http-echo" "/"
 RUN apk add curl
+
+# Create a non-root user to run the software.
+RUN addgroup http-echo
+RUN adduser -S -G http-echo 100
+
+COPY pkg/bin/linux_${TARGETARCH}/${BIN_NAME} /bin
+COPY cni/pkg/bin/linux_${TARGETARCH}/${CNI_BIN_NAME} /bin
+
+USER 100
 ENTRYPOINT ["/http-echo"]

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -8,8 +8,5 @@ RUN apk add curl
 RUN addgroup http-echo
 RUN adduser -S -G http-echo 100
 
-COPY pkg/bin/linux_${TARGETARCH}/${BIN_NAME} /bin
-COPY cni/pkg/bin/linux_${TARGETARCH}/${CNI_BIN_NAME} /bin
-
 USER 100
 ENTRYPOINT ["/http-echo"]


### PR DESCRIPTION
We must run as non-root users in order to support Kubernetes-1.25 [PodSecurityStandards](https://kubernetes.io/docs/concepts/security/pod-security-standards/) which bans root users when using certain policies like:

```
demo $ kubectl label --overwrite ns default \
   pod-security.kubernetes.io/enforce=restricted \
   pod-security.kubernetes.io/enforce-version=v1.24
```