### PR TITLE
user non root user

### DIFF
--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -7,4 +7,10 @@ ARG TARGETARCH
 ADD "https://curl.haxx.se/ca/cacert.pem" "/etc/ssl/certs/ca-certificates.crt"
 ADD "./pkg/${TARGETOS}_${TARGETARCH}/http-echo" "/"
 RUN apk add curl
+
+# Create a non-root user to run the software.
+RUN addgroup http-echo
+RUN adduser -S -G http-echo 100
+USER 100
+
 ENTRYPOINT ["/http-echo"]


### PR DESCRIPTION
We must run as non-root users in order to support Kubernetes-1.25 [PodSecurityStandards](https://kubernetes.io/docs/concepts/security/pod-security-standards/) which bans root users when using certain policies like:

demo $ kubectl label --overwrite ns default \
   pod-security.kubernetes.io/enforce=restricted \
   pod-security.kubernetes.io/enforce-version=v1.24