### PR TITLE
Reopen: Added possibility to change response status code 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,8 @@ GPG_KEY ?=
 LD_FLAGS ?= \
 	-s \
 	-w \
-	-X ${PROJECT}/version.Name=${NAME} \
-	-X ${PROJECT}/version.GitCommit=${GIT_COMMIT}
+	-X 'github.com/hashicorp/http-echo/version.Name=${NAME}' \
+	-X 'github.com/hashicorp/http-echo/version.GitCommit=${GIT_COMMIT}'
 
 # List of Docker targets to build
 DOCKER_TARGETS ?= scratch alpine

--- a/handlers.go
+++ b/handlers.go
@@ -18,8 +18,9 @@ const (
 )
 
 // withAppHeaders adds application headers such as X-App-Version and X-App-Name.
-func withAppHeaders(h http.HandlerFunc) http.HandlerFunc {
+func withAppHeaders(c int, h http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(c)
 		w.Header().Set(httpHeaderAppName, version.Name)
 		w.Header().Set(httpHeaderAppVersion, version.Version)
 		h(w, r)

--- a/handlers.go
+++ b/handlers.go
@@ -20,9 +20,9 @@ const (
 // withAppHeaders adds application headers such as X-App-Version and X-App-Name.
 func withAppHeaders(c int, h http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(c)
 		w.Header().Set(httpHeaderAppName, version.Name)
 		w.Header().Set(httpHeaderAppVersion, version.Version)
+		w.WriteHeader(c)
 		h(w, r)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -15,10 +15,10 @@ import (
 )
 
 var (
-	listenFlag     = flag.String("listen", ":5678", "address and port to listen")
-	textFlag       = flag.String("text", "", "text to put on the webpage")
-	versionFlag    = flag.Bool("version", false, "display version information")
-	statusCodeFlag = flag.Int("statusCode", 200, "response http code")
+	listenFlag  = flag.String("listen", ":5678", "address and port to listen")
+	textFlag    = flag.String("text", "", "text to put on the webpage")
+	versionFlag = flag.Bool("version", false, "display version information")
+	statusFlag  = flag.Int("status-code", 200, "http response code, e.g.: 200")
 
 	// stdoutW and stderrW are for overriding in test.
 	stdoutW = os.Stdout
@@ -54,7 +54,7 @@ func main() {
 
 	// Flag gets printed as a page
 	mux := http.NewServeMux()
-	mux.HandleFunc("/", httpLog(stdoutW, withAppHeaders(*statusCodeFlag, httpEcho(echoText))))
+	mux.HandleFunc("/", httpLog(stdoutW, withAppHeaders(*statusFlag, httpEcho(echoText))))
 
 	// Health endpoint
 	mux.HandleFunc("/health", withAppHeaders(200, httpHealth()))

--- a/main.go
+++ b/main.go
@@ -15,9 +15,10 @@ import (
 )
 
 var (
-	listenFlag  = flag.String("listen", ":5678", "address and port to listen")
-	textFlag    = flag.String("text", "", "text to put on the webpage")
-	versionFlag = flag.Bool("version", false, "display version information")
+	listenFlag     = flag.String("listen", ":5678", "address and port to listen")
+	textFlag       = flag.String("text", "", "text to put on the webpage")
+	versionFlag    = flag.Bool("version", false, "display version information")
+	statusCodeFlag = flag.Int("statusCode", 200, "response http code")
 
 	// stdoutW and stderrW are for overriding in test.
 	stdoutW = os.Stdout
@@ -53,10 +54,10 @@ func main() {
 
 	// Flag gets printed as a page
 	mux := http.NewServeMux()
-	mux.HandleFunc("/", httpLog(stdoutW, withAppHeaders(httpEcho(echoText))))
+	mux.HandleFunc("/", httpLog(stdoutW, withAppHeaders(*statusCodeFlag, httpEcho(echoText))))
 
 	// Health endpoint
-	mux.HandleFunc("/health", withAppHeaders(httpHealth()))
+	mux.HandleFunc("/health", withAppHeaders(200, httpHealth()))
 
 	server := &http.Server{
 		Addr:    *listenFlag,


### PR DESCRIPTION
Reopen #1 from @Gigitsu.  In the interest of time (both that we'll be performing the release and the PR is relatively old) I've pulled in the changes and made edits myself.

For reference here:
* refactor `WriteHeader`
* kebab case cli flag
* fix the LDFlags, which weren't being populated