### PR TITLE
chore: provide a default message

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,8 +15,9 @@ import (
 )
 
 var (
-	listenFlag  = flag.String("listen", ":5678", "address and port to listen")
-	textFlag    = flag.String("text", "", "text to put on the webpage")
+	listenFlag = flag.String("listen", ":5678", "address and port to listen")
+	textFlag   = flag.String("text", "hello world!, put your message here",
+		"text to put on the webpage")
 	versionFlag = flag.Bool("version", false, "display version information")
 	statusFlag  = flag.Int("status-code", 200, "http response code, e.g.: 200")
 
@@ -38,12 +39,6 @@ func main() {
 	echoText := os.Getenv("ECHO_TEXT")
 	if *textFlag != "" {
 		echoText = *textFlag
-	}
-
-	// Validation
-	if echoText == "" {
-		fmt.Fprintln(stderrW, "Missing -text option or ECHO_TEXT env var!")
-		os.Exit(127)
 	}
 
 	args := flag.Args()


### PR DESCRIPTION
### What is the purpose of this PR: 
This PR provides a default message for the `text` argument that can be used when not provided by the user through the terminal.
This is handy if you don't mind the message but you just need an echo server that can respond to operations like curl , wget , ... 
for instance when creating a deployment in Kubernetes you can use this image with no extra option/command as a container image which is  specially useful during an demo session. 

