### PR TITLE
remove serverCh, fix exit code

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,13 +66,11 @@ func main() {
 		Addr:    *listenFlag,
 		Handler: mux,
 	}
-	serverCh := make(chan struct{})
 	go func() {
 		log.Printf("[INFO] server is listening on %s\n", *listenFlag)
 		if err := server.ListenAndServe(); err != http.ErrServerClosed {
 			log.Fatalf("[ERR] server exited with: %s", err)
 		}
-		close(serverCh)
 	}()
 
 	signalCh := make(chan os.Signal, 1)
@@ -89,8 +87,7 @@ func main() {
 		log.Fatalf("[ERR] failed to shutdown server: %s", err)
 	}
 
-	// If we got this far, it was an interrupt, so don't exit cleanly
-	os.Exit(2)
+	os.Exit(0)
 }
 
 func httpEcho(v string) http.HandlerFunc {


### PR DESCRIPTION
Correct me if I'm overlooking something, but the serverCh serves no function (anymore?), and `server.Shutdown()` returns normally if the shutdown worked, so we get to the end of main() and want to exit 0, not 2. I could definitely reproduce that the current upstream version always exits 2 when terminated with SIGTERM/SIGINT, which is at the very least an annoyance.