### PR TITLE
add license file to linux distribution and docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,6 +87,7 @@ jobs:
           arch: ${{ matrix.goarch }}
           reproducible: report
           instructions: |
+            cp LICENSE $TARGET_DIR/LICENSE.txt
             make build
 
   build-linux:
@@ -119,6 +120,7 @@ jobs:
           arch: ${{ matrix.goarch }}
           reproducible: report
           instructions: |
+            cp LICENSE $TARGET_DIR/LICENSE.txt
             make build
 
   build-darwin:
@@ -154,6 +156,7 @@ jobs:
           arch: ${{ matrix.goarch }}
           reproducible: report
           instructions: |
+            cp LICENSE $TARGET_DIR/LICENSE.txt
             make build
 
   build-docker-default:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,15 +8,18 @@ ARG TARGETOS
 ARG TARGETARCH
 ARG PRODUCT_VERSION
 ARG BIN_NAME
+ENV PRODUCT_NAME=$BIN_NAME
 
 LABEL name="http-echo" \
       maintainer="HashiCorp Consul Team <consul@hashicorp.com>" \
       vendor="HashiCorp" \
       version=$PRODUCT_VERSION \
       release=$PRODUCT_VERSION \
-      summary="A test webserver that echos a response. You know, for kids." 
+      licenses="MPL-2.0" \
+      summary="A test webserver that echos a response. You know, for kids."
 
 COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME /
+COPY LICENSE /usr/share/doc/$PRODUCT_NAME/LICENSE.txt
 
 EXPOSE 5678/tcp
 


### PR DESCRIPTION
We have missing LICENSE file in the compiled artifacts, this PR adds this.

DoD

- [x] Add license file into ZIP
- [x] Add license file into docker image
- [x] Add license label into docker image